### PR TITLE
refactor: Refactor MaskedEq poly for improved testing and performance

### DIFF
--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -123,7 +123,7 @@ impl<E: Engine> WitnessBoundSumcheck<E> {
     assert!(num_vars_log < num_rounds);
 
     let tau_coords = PowPolynomial::new(&tau, num_rounds).coordinates();
-    let poly_masked_eq_evals = MaskedEqPolynomial::new(tau_coords, num_vars_log).evals();
+    let poly_masked_eq_evals = MaskedEqPolynomial::new(&EqPolynomial::new(tau_coords), num_vars_log).evals();
 
     Self {
       poly_W: MultilinearPolynomial::new(poly_W_padded),
@@ -972,11 +972,12 @@ where
 
         let (eq_tau, eq_masked_tau) = {
           let tau_coords = PowPolynomial::new(&tau, num_rounds_i).coordinates();
+          let eq_tau = EqPolynomial::new(tau_coords);
 
-          let eq_tau = EqPolynomial::new(tau_coords.clone()).evaluate(&rand_sc);
-          let eq_masked_tau = MaskedEqPolynomial::new(tau_coords, num_vars_log).evaluate(&rand_sc);
+          let eq_tau_at_rand = eq_tau.evaluate(rand_sc);
+          let eq_masked_tau = MaskedEqPolynomial::new(&eq_tau, num_vars_log).evaluate(rand_sc);
 
-          (eq_tau, eq_masked_tau)
+          (eq_tau_at_rand, eq_masked_tau)
         };
 
         // Evaluate identity polynomial

--- a/src/spartan/polys/masked_eq.rs
+++ b/src/spartan/polys/masked_eq.rs
@@ -9,17 +9,17 @@ use itertools::zip_eq;
 ///
 /// The polynomial is defined by the formula:
 /// eqₘ(x,r) = eq(x,r) - ( ∏_{0 ≤ i < n-m} (1−rᵢ)(1−xᵢ) )⋅( ∏_{n-m ≤ i < n} (1−rᵢ)(1−xᵢ) + rᵢ⋅xᵢ )
-pub struct MaskedEqPolynomial<Scalar: PrimeField> {
-  eq: EqPolynomial<Scalar>,
+pub struct MaskedEqPolynomial<'a, Scalar: PrimeField> {
+  eq: &'a EqPolynomial<Scalar>,
   num_masked_vars: usize,
 }
 
-impl<Scalar: PrimeField> MaskedEqPolynomial<Scalar> {
+impl<'a, Scalar: PrimeField> MaskedEqPolynomial<'a, Scalar> {
   /// Creates a new `MaskedEqPolynomial` from a vector of Scalars `r` of size n, with the number of
   /// masked variables m = `num_masked_vars`.
-  pub const fn new(r: Vec<Scalar>, num_masked_vars: usize) -> Self {
+  pub const fn new(eq: &'a EqPolynomial<Scalar>, num_masked_vars: usize) -> Self {
     MaskedEqPolynomial {
-      eq: EqPolynomial::new(r),
+      eq,
       num_masked_vars,
     }
   }
@@ -100,10 +100,10 @@ mod tests {
       .take(num_vars)
       .collect::<Vec<_>>();
 
-    let poly_eq = EqPolynomial::new(r.clone());
+    let poly_eq = EqPolynomial::new(r);
     let poly_eq_evals = poly_eq.evals();
 
-    let masked_eq_poly = MaskedEqPolynomial::new(r, num_masked_vars);
+    let masked_eq_poly = MaskedEqPolynomial::new(&poly_eq, num_masked_vars);
     let masked_eq_poly_evals = masked_eq_poly.evals();
 
     // ensure the first 2^m entries are 0


### PR DESCRIPTION
- Introduce lifetime parameters to `MaskedEqPolynomial` struct to improve memory management.
- Modify the `MaskedEqPolynomial` creation process so it now requires a reference to an existing `EqPolynomial`.
- Adapt corresponding tests to reflect the above changes.